### PR TITLE
Update batch_ingest_sm_pyspark.py

### DIFF
--- a/05-module-scalable-batch-ingestion/scripts/batch_ingest_sm_pyspark.py
+++ b/05-module-scalable-batch-ingestion/scripts/batch_ingest_sm_pyspark.py
@@ -23,7 +23,8 @@ def transform_row(row) -> list:
     record = []
     for column in columns:
         feature = {'FeatureName': column, 'ValueAsString': str(row[column])}
-        record.append(feature)
+        if str(row[column]) not in ['NaN', 'NA', 'None', 'nan', 'none']:
+            record.append(feature)
     return record
 
 


### PR DESCRIPTION
Null feature values can't be ingested into a feature group. This line of code stops the code from following error:

Attempted to parse the feature value for the feature named [z] into a FeatureValue of type Fractional. The provided value must be within the range of a double precision floating point number defined by the IEEE 754 standard. The input format can be in either decimal form or scientific notation.

*Issue #, if available:*

*Description of changes:*
Current code throws error if there is any missing value in the record that you want to ingest. The proposed changes stops the feature name and value to be added to the record list if the feature is missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
