### PR TITLE
feat: fix SettingWithCopyWarning warning

### DIFF
--- a/01-module-feature-store-foundations/m1_nb0_prepare_datasets.ipynb
+++ b/01-module-feature-store-foundations/m1_nb0_prepare_datasets.ipynb
@@ -775,7 +775,7 @@
     "\n",
     "while current_end_date <= end_date:\n",
     "    print(f'Dates between {current_start_date} and {current_end_date}')\n",
-    "    partitions_df = orders_df[orders_df['purchased_on'].between(current_start_date, current_end_date)]\n",
+    "    partitions_df = orders_df[orders_df['purchased_on'].between(current_start_date, current_end_date)].copy()\n",
     "    partitions_df.drop('purchased_on', axis=1, inplace=True)\n",
     "    partition = f'{current_start_date.strftime(\"%Y\")}-{int(current_start_date.strftime(\"%m\"))}'    \n",
     "    current_partitions_path = f'{partitions_path}/{partition}'\n",


### PR DESCRIPTION
The `SettingWithCopyWarning` warning occurs when we modify the data in the orders_df.

To fix this warning, just use the `copy` method to create a copy.